### PR TITLE
Piper/flag players as inactive

### DIFF
--- a/bughouse/api/v1/serializers.py
+++ b/bughouse/api/v1/serializers.py
@@ -39,6 +39,9 @@ class PlayerSerializer(serializers.ModelSerializer):
     icon = B64ImageField(write_only=True, required=False)
     icon_filename = serializers.CharField(write_only=True, required=False)
 
+    latest_rating = serializers.FloatField(read_only=True)
+    total_games = serializers.IntegerField(read_only=True)
+
     def validate(self, data):
         icon = data.get('icon')
         icon_filename = data.get('icon_filename')
@@ -70,6 +73,9 @@ class PlayerSerializer(serializers.ModelSerializer):
             'icon',
             'icon_filename',
             'icon_url',
+            'is_active',
+            'total_games',
+            'latest_rating',
         )
 
     def save(self, *args, **kwargs):

--- a/bughouse/migrations/0004_auto_20150210_2339.py
+++ b/bughouse/migrations/0004_auto_20150210_2339.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('bughouse', '0003_auto_20150207_1846'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='player',
+            name='is_active',
+            field=models.BooleanField(default=True),
+            preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='team',
+            name='black_player',
+            field=models.ForeignKey(related_name='teams_as_black', on_delete=django.db.models.deletion.PROTECT, to='bughouse.Player'),
+            preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='team',
+            name='white_player',
+            field=models.ForeignKey(related_name='teams_as_white', on_delete=django.db.models.deletion.PROTECT, to='bughouse.Player'),
+            preserve_default=True,
+        ),
+    ]

--- a/bughouse/models.py
+++ b/bughouse/models.py
@@ -23,6 +23,8 @@ class Player(Timestamped):
     name = models.CharField(max_length=255, unique=True)
     icon = models.ImageField()
 
+    is_active = models.BooleanField(default=True, blank=True)
+
     def __str__(self):
         return self.name
 

--- a/bughouse/static/js/player-rating-visualizations/app.js
+++ b/bughouse/static/js/player-rating-visualizations/app.js
@@ -11,13 +11,10 @@ $(function(){
             this.graph_layout = new app.GraphLayout({
                 application: this
             });
-            //this.graph_layout.graph.show(new app.PlayerGraphView({
-            //    model: this.players.first()
-            //}));
             this.graph_layout.players.show(new app.PlayersView({
                 collection: this.players
             }));
-            this.graph_layout.arst.show(new app.GraphView({
+            this.graph_layout.graph.show(new app.GraphView({
                 collection: this.players
             }));
         },

--- a/bughouse/static/js/player-rating-visualizations/layouts.js
+++ b/bughouse/static/js/player-rating-visualizations/layouts.js
@@ -10,7 +10,6 @@ $(function(){
         el: "#application",
         regions: {
             players: "#players",
-            arst: "#arst",
             graph: "#graph"
         },
     });

--- a/bughouse/static/js/player-rating-visualizations/views.js
+++ b/bughouse/static/js/player-rating-visualizations/views.js
@@ -4,13 +4,16 @@ $(function(){
     "use-strict";
 
     var SinglePlayerView = Backbone.Marionette.ItemView.extend({
+        initialize: function(options) {
+            this.listenTo(this.model, "change:isSelected", this.render);
+        },
         tagName: "div",
         template: Handlebars.templates.single_player,
         events: {
-            "click img": "toggleSelection",
-            "change:isSelected": "render"
+            "click a img": "toggleSelection"
         },
-        toggleSelection: function() {
+        toggleSelection: function(event) {
+            event.preventDefault();
             this.model.set("isSelected", !this.model.get("isSelected"));
         }
     });

--- a/bughouse/static/js/player-roster/views.js
+++ b/bughouse/static/js/player-roster/views.js
@@ -10,6 +10,7 @@ $(function(){
             "click img": "triggerEdit"
         },
         triggerEdit: function(event) {
+            event.preventDefault();
             this.trigger("player:edit");
         }
     });

--- a/bughouse/static/js/player-roster/views.js
+++ b/bughouse/static/js/player-roster/views.js
@@ -63,6 +63,8 @@ $(function(){
                 this.model.set("name", el.val());
             } else if ( el.attr("name") === "icon" ) {
                 this.handleIconSelect(event);
+            } else if ( el.attr("name") === "isActive" ) {
+                this.model.set("is_active", el.prop("checked"));
             }
         },
         /*
@@ -99,7 +101,8 @@ $(function(){
 
                 reader.readAsBinaryString(file);
             } else {
-                this.set("icon", null);
+                this.unset("icon");
+                this.unset("icon_filename");
             }
         },
         /*

--- a/bughouse/static/js/report-game/app.js
+++ b/bughouse/static/js/report-game/app.js
@@ -33,12 +33,12 @@ $(function(){
             this.game_form_layout.winning_team.show(new app.PlayerSelectView({
                 isWinners: true,
                 model: game,
-                collection: this.players
+                collection: new Backbone.Collection(this.players.where({'is_active': true}))
             }));
             this.game_form_layout.losing_team.show(new app.PlayerSelectView({
                 isWinners: false,
                 model: game,
-                collection: this.players
+                collection: new Backbone.Collection(this.players.where({'is_active': true}))
             }));
         },
         setupLossTypeSelect: function(game) {

--- a/bughouse/static/js/templates/player_form.handlebars
+++ b/bughouse/static/js/templates/player_form.handlebars
@@ -1,22 +1,42 @@
 <form id="player-form" action="." method="post">
-    <div class="form-group">
-        <label for="name">Name</label>
-        <input class="form-control" name="name" placeholder="Player Name" value="{{ name }}">
+    {{#unless isNew }}
+    <div class="panel panel-default">
+        <div class="panel-heading">
+            <h3>{{ name }} <span class="badge">{{ latest_rating }}</span></h3>
+        </div>
+        <div class="panel-body">
+            <div class="media-left">
+                <a href="#" class="thumbnail">
+                    <img src="{{ icon_url }}" class="img-circle">
+                </a>
+            </div>
+            <div class="media-right">
+                <p>Sure would be nice if I had something to put here....</p>
+            </div>
+        </div>
+        <div class="panel-footer">
+            <div class="checkbox">
+                <label>
+                    <input type="checkbox" name="isActive"{{#if is_active }} checked{{/if}}> Active
+                </label>
+            </div>
+        </div>
     </div>
+    {{/unless}}
     {{#if isNew }}
+        <div class="form-group">
+            <label for="name">Name</label>
+            <input class="form-control" name="name" placeholder="Player Name" value="{{ name }}">
+        </div>
         <div class="form-group">
             <label for="icon">Icon</label>
             <input type="file" name="icon">
             <p class="help-block">Images should be at least 200x200</p>
         </div>
-    {{else}}
-        <div>
-            <img src="{{ icon_url }}" class="img-circle">
-        </div>
     {{/if}}
-        <button class="submit btn btn-lg btn-success">
-            {{#if isNew }}Create{{else}}Save{{/if}}
-        </button>
+    <button class="submit btn btn-lg btn-success">
+        {{#if isNew }}Create{{else}}Save{{/if}}
+    </button>
     {{#unless isNew }}
         <button class="cancel btn btn-lg btn-primary">Cancel</button>
     {{/unless}}

--- a/bughouse/static/js/templates/roster_player.handlebars
+++ b/bughouse/static/js/templates/roster_player.handlebars
@@ -1,4 +1,6 @@
 <div class="col-md-2">
-    <h3>{{ name }}</h3>
-    <img src="{{ icon_url }}" class="img-circle">
+    <h3>{{ name }} <span class="badge">{{ latest_rating }}</span></h3>
+    <a href="#" class="thumbnail">
+        <img src="{{ icon_url }}" class="img-circle">
+    </a>
 </div>

--- a/bughouse/static/js/templates/single_player.handlebars
+++ b/bughouse/static/js/templates/single_player.handlebars
@@ -1,1 +1,5 @@
-<img src="{{ icon_url }}" id="{{ name }}"/>
+<div class="col-md-1">
+    <a href="" class="thumbnail">
+        <img src="{{ icon_url }}" id="{{ name }}" class="{{#if isSelected }}img-circle{{else}}img-rounded{{/if}}"/>
+    </a>
+</div>

--- a/bughouse/templates/bughouse/player-rating-visualization.html
+++ b/bughouse/templates/bughouse/player-rating-visualization.html
@@ -12,13 +12,9 @@
 
 {% block content %}
 <div id="application" class="container">
+    <div class="row" id="players">
+    </div>
     <div id="graph">
-    </div>
-
-    <div id="arst">
-    </div>
-
-    <div id="players">
     </div>
 </div>
 {% endblock content %}


### PR DESCRIPTION
### What is the problem / feature ?

Visualizations page is fugly.
Player editing is weird.

### How did it get fixed / implemented ?

- You can no longer edit player fields.
- You can now mark a player as inactive which excludes them from the game reporting form.
- The player visualization images are now small and across the top.

### How can someone test / see it ?

Load up teh app.



*Here is a cute animal picture for your troubles...*


![unlikely-animal-friends-fox-cockerel](https://cloud.githubusercontent.com/assets/824194/6140078/b6b6c0bc-b150-11e4-8f15-f105202ef0bc.jpg)
