### PR TITLE
remove provisional modifier

### DIFF
--- a/bughouse/ratings/engines/batman.py
+++ b/bughouse/ratings/engines/batman.py
@@ -1,5 +1,3 @@
-from django.conf import settings
-
 from bughouse.models import EXPERIMENTAL_BATMAN
 from bughouse.ratings.utils import round_it
 from bughouse.ratings.engines.base import BaseRatingsEngine
@@ -7,27 +5,27 @@ from bughouse.ratings.engines.base import BaseRatingsEngine
 
 def elo_chance_to_lose(player, other):
     """
-    other_rank + 400 * (wins - losses)
-    ----------------------------------
-               games
-
-    new = old + C * (score - expected)
-
     Probability = 1 / (1 + (10 ^ -((White Rating - Black Rating) / 400)))
-
-    Black Adjustment = Int (-1 * (White Adjustment * Black's DeltaK / White's DeltaK))
-
-    White Adjustment = Int (DeltaK * (Score - Probability) )
-
-    1-0, score = 1.
-    1/2-1/2, score = 0.5.
-    0-1, score = 0.
     """
     diff = player - other
     return 1.0 / (1 + pow(10, (diff / 400.0)))
 
 
-def adjust_ratings(player, opponent, partner, opponent_partner, scalar=3):
+def get_delta_k(rating):
+    """
+    DeltaK = 32 where the players rating <= 2100.
+    DeltaK = 24 where the players rating > 2100 and < 2400.
+    DeltaK = 16 where the players rating > 2400.
+    """
+    if rating <= 2100:
+        return 32
+    elif 2100 < rating <= 2400:
+        return 24
+    else:
+        return 16
+
+
+def adjust_ratings(player, opponent, partner, opponent_partner, scalar=2):
     """
     Adjust a player's ELO rating based on his partner matchup.
     """
@@ -36,13 +34,21 @@ def adjust_ratings(player, opponent, partner, opponent_partner, scalar=3):
         partner,
     ))
     partner_diff = partner - opponent_partner
-    diff = (player + partner_diff * partner_probability * scalar) - opponent
-    return round_it(opponent + diff)
+    adjusted_rating = player + (partner_diff * partner_probability * scalar)
+    return round_it(adjusted_rating)
 
 
-def points_from_probability(probability_to_win, victory_condition_constant):
+def compute_points(delta_k, outcome_probability, other=False):
+    """
+    - If the outcome was likely, then you receive fewer points.
+    - If the outcome was unlikely, then you receive more points.
+    """
+    if other:
+        scale = 0.9
+    else:
+        scale = 1
     return round_it(
-        (1 - probability_to_win) * victory_condition_constant
+        delta_k * (1 - outcome_probability) * scale
     )
 
 
@@ -52,20 +58,29 @@ def compute_individual_ratings(winner, winner_partner, loser, loser_partner):
     l1_adjusted = adjust_ratings(loser, winner, loser_partner, winner_partner)
     l2_adjusted = adjust_ratings(loser_partner, winner_partner, loser, winner)
 
-    w1_prob = 1 - elo_chance_to_lose(w1_adjusted, l1_adjusted)
-    w2_prob = 1 - elo_chance_to_lose(w2_adjusted, l2_adjusted)
-    l1_prob = elo_chance_to_lose(l1_adjusted, w1_adjusted)
-    l2_prob = elo_chance_to_lose(l2_adjusted, w2_adjusted)
+    w1_dk = get_delta_k(w1_adjusted)
+    w2_dk = get_delta_k(w2_adjusted)
+    l1_dk = get_delta_k(l1_adjusted)
+    l2_dk = get_delta_k(l2_adjusted)
 
-    w1_points = points_from_probability(w1_prob, settings.ELO_WIN_SELF)
-    w2_points = points_from_probability(w2_prob, settings.ELO_WIN_PARTNER)
-    l1_points = points_from_probability(l1_prob, settings.ELO_LOSE_SELF)
-    l2_points = points_from_probability(l2_prob, settings.ELO_LOSE_PARTNER)
+    w1_outcome_prob = 1 - elo_chance_to_lose(w1_adjusted, l1_adjusted)
+    w2_outcome_prob = 1 - elo_chance_to_lose(w2_adjusted, l2_adjusted)
+    l1_outcome_prob = elo_chance_to_lose(l1_adjusted, w1_adjusted)
+    l2_outcome_prob = elo_chance_to_lose(l2_adjusted, w2_adjusted)
+
+    # if your chance to win is high and you win - small addition
+    # if your chance to win is low and you win - large deduction
+    w1_points = compute_points(w1_dk, w1_outcome_prob)
+    w2_points = compute_points(w2_dk, w2_outcome_prob, True)
+    # if your chance to lose was high and you lose - small deduction
+    # if your chance to lose was low and you lose - large addition
+    l1_points = -1 * compute_points(l1_dk, l1_outcome_prob)
+    l2_points = -1 * compute_points(l2_dk, l2_outcome_prob, True)
 
     # for debugger purposes.
     bases = (winner, winner_partner, loser, loser_partner)
     adjusted = (w1_adjusted, w2_adjusted, l1_adjusted, l2_adjusted)
-    probs = (w1_prob, w2_prob, l1_prob, l2_prob)
+    probs = (w1_outcome_prob, w2_outcome_prob, l1_outcome_prob, l2_outcome_prob)
     points = (w1_points, w2_points, l1_points, l2_points)
 
     return w1_points, w2_points, l1_points, l2_points
@@ -142,26 +157,31 @@ def pad(s):
 
 
 def report_it(a, b, c, d, e=False):
-    pa = int(chance_of_loss(a, b, c, d) * 100)
+    aa = round_it(adjust_ratings(a, b, c, d))
+    ba = round_it(adjust_ratings(b, a, d, c))
+    ca = round_it(adjust_ratings(c, d, a, b))
+    da = round_it(adjust_ratings(d, c, b, a))
+
+    pa = int(elo_chance_to_lose(aa, ba) * 100)
     pb = int(abs(100 - pa))
-    pd = int(chance_of_loss(d, c, b, a) * 100)
-    pc = int(abs(100 - pd))
+    pc = int(elo_chance_to_lose(ca, da) * 100)
+    pd = int(abs(100 - pc))
 
     ra = int(elo_chance_to_lose(a, b) * 100)
     rb = int(abs(100 - ra))
-    rd = int(elo_chance_to_lose(d, c) * 100)
-    rc = int(abs(100 - rd))
+    rc = int(elo_chance_to_lose(c, d) * 100)
+    rd = int(abs(100 - rc))
 
     print "-----------------------------------"
     print "| {pa}% ({ra}%)  |  {pc}% ({rc}%) |".format(
         pa=pad(pa), ra=pad(ra), pc=pad(pc), rc=pad(rc),
     )
     print "-----------------------------------"
-    print "|      {aa}      |      {cc}      |".format(aa=pad(a), cc=pad(c))
+    print "| {aa}  ({oa})   | {cc}  ({oc})   |".format(aa=pad(aa), cc=pad(ca), oa=pad(a), oc=pad(c))
     print "-----------------------------------"
     print "|       vs       |       vs       |"
     print "-----------------------------------"
-    print "|      {bb}      |      {dd}      |".format(bb=pad(b), dd=pad(d))
+    print "| {bb}  ({ob})    | {dd}  ({od})  |".format(bb=pad(ba), dd=pad(da), ob=pad(b), od=pad(d))
     print "-----------------------------------"
     print "| {pb}% ({rb}%)  |  {pd}% ({rd}%) |".format(
         pb=pad(pb), rb=pad(rb), pd=pad(pd), rd=pad(rd),

--- a/tests/bughouse/ratings/batman/test_score_adjustment.py
+++ b/tests/bughouse/ratings/batman/test_score_adjustment.py
@@ -15,6 +15,6 @@ from bughouse.ratings.engines.batman import adjust_ratings
     ),
 )
 def test_adjusted_scores(base_ratings, expected):
-    actual = adjust_ratings(*base_ratings)
+    actual = adjust_ratings(*base_ratings, scalar=3)
 
     assert actual == expected

--- a/tests/bughouse/ratings/test_overall_overall_ratings.py
+++ b/tests/bughouse/ratings/test_overall_overall_ratings.py
@@ -8,7 +8,6 @@ from bughouse.models import (
 from bughouse.ratings.engines.overall import (
     rate_teams,
     rate_players,
-    provisional_modifier,
 )
 
 
@@ -16,8 +15,8 @@ def test_rate_single_game(factories, models, elo_settings):
     game = factories.GameFactory()
     r1, r2 = rate_teams(game)
 
-    assert r1.rating == 1024
-    assert r2.rating == 976
+    assert r1.rating == 1006
+    assert r2.rating == 994
 
 
 def test_rate_multiple_games(factories, models):
@@ -26,39 +25,8 @@ def test_rate_multiple_games(factories, models):
     rate_teams(factories.GameFactory(winning_team=team_a, losing_team=team_b))
     rate_teams(factories.GameFactory(winning_team=team_a, losing_team=team_b))
 
-    assert team_a.get_latest_rating(OVERALL_OVERALL) == 1052
-    assert team_b.get_latest_rating(OVERALL_OVERALL) == 948
-
-
-def test_provisional_limit(factories, models):
-    team_a = factories.TeamFactory()
-    team_b = factories.TeamFactory()
-
-    assert provisional_modifier(team_a) == 4
-
-    rate_teams(factories.GameFactory(winning_team=team_a, losing_team=team_b))
-    rate_teams(factories.GameFactory(winning_team=team_a, losing_team=team_b))
-    rate_teams(factories.GameFactory(winning_team=team_a, losing_team=team_b))
-    rate_teams(factories.GameFactory(winning_team=team_a, losing_team=team_b))
-    rate_teams(factories.GameFactory(winning_team=team_a, losing_team=team_b))
-    rate_teams(factories.GameFactory(winning_team=team_a, losing_team=team_b))
-
-    assert provisional_modifier(team_a) == 4
-
-    rate_teams(factories.GameFactory(winning_team=team_a, losing_team=team_b))
-    rate_teams(factories.GameFactory(winning_team=team_a, losing_team=team_b))
-    rate_teams(factories.GameFactory(winning_team=team_a, losing_team=team_b))
-    rate_teams(factories.GameFactory(winning_team=team_a, losing_team=team_b))
-    rate_teams(factories.GameFactory(winning_team=team_a, losing_team=team_b))
-
-    assert team_a.total_games == 11
-    assert provisional_modifier(team_a) == 1
-    assert (
-        team_a.get_latest_rating(OVERALL_OVERALL) > team_b.get_latest_rating(OVERALL_OVERALL)
-    )
-    assert (
-        team_a.get_latest_rating(OVERALL_OVERALL) + team_b.get_latest_rating(OVERALL_OVERALL)
-    ) / 2 == 1000
+    assert team_a.get_latest_rating(OVERALL_OVERALL) == 1012
+    assert team_b.get_latest_rating(OVERALL_OVERALL) == 988
 
 
 @pytest.mark.parametrize(
@@ -71,18 +39,18 @@ def test_individual_ratings(factories, models, losing_color):
     if game.losing_color == game.BLACK:
         wtwr, wtbr, ltwr, ltbr = rate_players(game)
 
-        assert wtwr.player.get_latest_rating(OVERALL_OVERALL) == 1028
-        assert wtbr.player.get_latest_rating(OVERALL_OVERALL) == 1024
-        assert ltwr.player.get_latest_rating(OVERALL_OVERALL) == 976
-        assert ltbr.player.get_latest_rating(OVERALL_OVERALL) == 972
+        assert wtwr.player.get_latest_rating(OVERALL_OVERALL) == 1007
+        assert wtbr.player.get_latest_rating(OVERALL_OVERALL) == 1006
+        assert ltwr.player.get_latest_rating(OVERALL_OVERALL) == 994
+        assert ltbr.player.get_latest_rating(OVERALL_OVERALL) == 993
 
     else:
         wtwr, wtbr, ltwr, ltbr = rate_players(game)
 
-        assert wtwr.player.get_latest_rating(OVERALL_OVERALL) == 1024
-        assert wtbr.player.get_latest_rating(OVERALL_OVERALL) == 1028
-        assert ltwr.player.get_latest_rating(OVERALL_OVERALL) == 972
-        assert ltbr.player.get_latest_rating(OVERALL_OVERALL) == 976
+        assert wtwr.player.get_latest_rating(OVERALL_OVERALL) == 1006
+        assert wtbr.player.get_latest_rating(OVERALL_OVERALL) == 1007
+        assert ltwr.player.get_latest_rating(OVERALL_OVERALL) == 993
+        assert ltbr.player.get_latest_rating(OVERALL_OVERALL) == 994
 
 
 def test_ratings_computation_is_idempotent(factories, models):

--- a/tests/bughouse/ratings/test_white_and_black_rankings.py
+++ b/tests/bughouse/ratings/test_white_and_black_rankings.py
@@ -14,18 +14,18 @@ def test_black_white_player_ratings(factories, models, elo_settings):
 
     factories.GameFactory(winning_team=team_a, losing_color=BLACK)
 
-    assert player.get_latest_rating(key=OVERALL_OVERALL) == 1028
-    assert player.get_latest_rating(key=OVERALL_WHITE) == 1028
+    assert player.get_latest_rating(key=OVERALL_OVERALL) == 1007
+    assert player.get_latest_rating(key=OVERALL_WHITE) == 1007
     assert player.get_latest_rating(key=OVERALL_BLACK) == 1000
 
     factories.GameFactory(winning_team=team_b, losing_color=WHITE)
 
-    assert player.get_latest_rating(key=OVERALL_OVERALL) == 1056
-    assert player.get_latest_rating(key=OVERALL_WHITE) == 1028
-    assert player.get_latest_rating(key=OVERALL_BLACK) == 1028
+    assert player.get_latest_rating(key=OVERALL_OVERALL) == 1014
+    assert player.get_latest_rating(key=OVERALL_WHITE) == 1007
+    assert player.get_latest_rating(key=OVERALL_BLACK) == 1007
 
     factories.GameFactory(winning_team=team_a, losing_color=BLACK)
 
-    assert player.get_latest_rating(key=OVERALL_OVERALL) == 1080
-    assert player.get_latest_rating(key=OVERALL_WHITE) == 1056
-    assert player.get_latest_rating(key=OVERALL_BLACK) == 1028
+    assert player.get_latest_rating(key=OVERALL_OVERALL) == 1021
+    assert player.get_latest_rating(key=OVERALL_WHITE) == 1014
+    assert player.get_latest_rating(key=OVERALL_BLACK) == 1007


### PR DESCRIPTION
- Remove the provisional modifier from the main ranking algorithm  @nathanlubchenco your call on whether this is ok.  It seems to cause problems when we try to compare two different ranking systems.
- Fix problems with the ranking adjustments for the batman ranking algorithm.

![unlikely-animal-friendships-alliances-6](https://cloud.githubusercontent.com/assets/824194/6260454/333323fa-b79c-11e4-81e8-6e7e83f475ac.jpg)
