### PR TITLE
Add regression test and fix for creating a player without an image.

### DIFF
--- a/bughouse/api/v1/serializers.py
+++ b/bughouse/api/v1/serializers.py
@@ -84,6 +84,16 @@ class PlayerSerializer(serializers.ModelSerializer):
             )
         return value
 
+    def validate_image_for_player_create(self, icon_filename, icon):
+        if not icon_filename:
+            raise serializers.ValidationError(
+                "`icon_filename` is required for player creation"
+            )
+        if not icon:
+            raise serializers.ValidationError(
+                "`icon` is required for player creation"
+            )
+
     class Meta:
         model = Player
         fields = (
@@ -104,6 +114,8 @@ class PlayerSerializer(serializers.ModelSerializer):
     def save(self, *args, **kwargs):
         icon_filename = self.validated_data.pop("icon_filename", None)
         icon = self.validated_data.pop('icon', None)
+        if not self.instance:
+            self.validate_image_for_player_create(icon_filename, icon)
         player = super(PlayerSerializer, self).save(*args, **kwargs)
         if icon_filename and icon:
             player.icon.save(

--- a/tests/bughouse/api/test_player_endpoints.py
+++ b/tests/bughouse/api/test_player_endpoints.py
@@ -11,10 +11,11 @@ from bughouse.models import Player
 def test_player_creation():
     client = APIClient()
     url = reverse('v1:player-list')
-    response = client.post(url, {'name': 'jeff'}, format='json')
+    client.post(url, {'name': 'jeff'}, format='json')
 
     # Should fail without an image
     assert Player.objects.filter(name='jeff').count() == 0
+
 
 @pytest.mark.django_db
 def test_player_name_update(factories):

--- a/tests/bughouse/api/test_player_endpoints.py
+++ b/tests/bughouse/api/test_player_endpoints.py
@@ -1,0 +1,30 @@
+import pytest
+
+from django.core.urlresolvers import reverse
+
+from rest_framework.test import APIClient
+
+from bughouse.models import Player
+
+
+@pytest.mark.django_db
+def test_player_creation():
+    client = APIClient()
+    url = reverse('v1:player-list')
+    response = client.post(url, {'name': 'jeff'}, format='json')
+
+    # Should fail without an image
+    assert Player.objects.filter(name='jeff').count() == 0
+
+@pytest.mark.django_db
+def test_player_name_update(factories):
+    player = factories.PlayerFactory()
+    original_name = player.name
+
+    client = APIClient()
+    url = reverse('v1:player-detail', kwargs={'pk': player.id})
+    client.put(url, {'name': 'jeff'}, format='json')
+
+    updated_player = Player.objects.get(id=player.id)
+    assert updated_player.name == 'jeff'
+    assert Player.objects.filter(name=original_name).count() == 0


### PR DESCRIPTION
Resolves issue #29.

I wasn't sure how to update my last PR in github, so here's another one. Tests pass locally this time.

This commit also adds some view-based regression tests, as the previous error slipped between the serializer testing.
